### PR TITLE
Trashy temporary fix to the problem with MATH 7203

### DIFF
--- a/common/search.js
+++ b/common/search.js
@@ -312,7 +312,9 @@ class Search {
     // Acronyms such as ood and ai and ml are generated dynamically based on the name
     let slangMap = {
       fundies: 'fundamentals of computer science',
-      orgo: 'Organic Chemistry'
+      orgo: 'Organic Chemistry',
+      numeri: 'MATH 7203',
+      numerica: 'MATH 7203'
     }
 
     for (const word in slangMap) {


### PR DESCRIPTION
When looking up "Numerical Reasoning", there would be no results for "numeri" or "numerica". This is a trashy fix to that issue.