### PR TITLE
Fixed rest of the ESLint issues and made it required on Travis-CI and in the webpack build

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     'prefer-destructuring': 0,
     'jsx-a11y/click-events-have-key-events': 0,
     'jsx-a11y/no-noninteractive-element-interactions': 0,
+    'jsx-a11y/anchor-is-valid': 0,
 
     // Allow for-of loops. 
     "no-restricted-syntax": [

--- a/backend/scrapers/classes/processors/tests/addPreRequisiteFor.test.js
+++ b/backend/scrapers/classes/processors/tests/addPreRequisiteFor.test.js
@@ -4,7 +4,7 @@
  */
 
 import addPreRequisiteFor from '../addPreRequisiteFor';
-import Keys from '../../../../../common/Keys';
+// import Keys from '../../../../../common/Keys';
 
 describe('addPreRequisiteFor tests', () => {
   const cs2500 = {

--- a/backend/webpack.config.babel.js
+++ b/backend/webpack.config.babel.js
@@ -85,17 +85,16 @@ export default {
   module: {
     loaders: [
 
-    // Enable this once everything passes the linting.
-    // {
-    //    enforce: "pre",
-    //     test: /\.js$/,
-    //     exclude: /node_modules/,
-    //     use: [
-    //       "babel-loader",
-    //       "eslint-loader",
-    //     ],
-    //   },
-
+    // Ensure that everything passes eslint. 
+    {
+       enforce: "pre",
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: [
+          "babel-loader",
+          "eslint-loader",
+        ],
+      },
       {
         test: /\.js$/,
         loader: 'babel-loader',

--- a/backend/webpack.config.babel.js
+++ b/backend/webpack.config.babel.js
@@ -85,14 +85,14 @@ export default {
   module: {
     loaders: [
 
-    // Ensure that everything passes eslint. 
-    {
-       enforce: "pre",
+    // Ensure that everything passes eslint.
+      {
+        enforce: 'pre',
         test: /\.js$/,
         exclude: /node_modules/,
         use: [
-          "babel-loader",
-          "eslint-loader",
+          'babel-loader',
+          'eslint-loader',
         ],
       },
       {

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -83,7 +83,7 @@ yarn build_backend # build only the backend
 
 ### Linting
 
-Some of the code follows the ESLint config. Right now it is not required that code pass the linting but it may be required in the future. 
+Some of the code follows the ESLint config. All the code in the codebase should pass these linting checks. 
 
 ```bash
 yarn lint

--- a/frontend/components/Home.js
+++ b/frontend/components/Home.js
@@ -30,6 +30,26 @@ class Home extends React.Component {
   constructor(props) {
     super(props);
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
     let selectedTerm;
     // Check localStorage for the most recently selected term. Keeping this in localStorage makes it sticky across page loads/
     if (localStorage.selectedTerm) {

--- a/frontend/components/Home.js
+++ b/frontend/components/Home.js
@@ -30,26 +30,6 @@ class Home extends React.Component {
   constructor(props) {
     super(props);
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     let selectedTerm;
     // Check localStorage for the most recently selected term. Keeping this in localStorage makes it sticky across page loads/
     if (localStorage.selectedTerm) {

--- a/frontend/components/ResultsLoader.js
+++ b/frontend/components/ResultsLoader.js
@@ -146,6 +146,7 @@ ResultsLoader.loadedClassObjects = {};
 
 ResultsLoader.propTypes = {
   results: PropTypes.array.isRequired,
+  loadMore: PropTypes.func.isRequired,
 };
 
 

--- a/frontend/components/SplashPage/SplashPage.js
+++ b/frontend/components/SplashPage/SplashPage.js
@@ -18,82 +18,80 @@ import oodMobile2 from './ood mobile 2.png';
 import css from './SplashPage.css';
 import macros from '../macros';
 
-class SplashPage extends React.Component {
-  render() {
-    // Events that fire when the buttons are clicked.
-    const searchForCS2510Event = new CustomEvent(macros.searchEvent, { detail: 'CS 2510' });
-    const searchForENGW1111Event = new CustomEvent(macros.searchEvent, { detail: 'ENGW 1111' });
-    const searchForOODEvent = new CustomEvent(macros.searchEvent, { detail: 'OOD' });
+function SplashPage() {
+  // Events that fire when the buttons are clicked.
+  const searchForCS2510Event = new CustomEvent(macros.searchEvent, { detail: 'CS 2510' });
+  const searchForENGW1111Event = new CustomEvent(macros.searchEvent, { detail: 'ENGW 1111' });
+  const searchForOODEvent = new CustomEvent(macros.searchEvent, { detail: 'OOD' });
 
-    // <img className = {css.lernerMobile} src={lernerMobile}/>
+  // <img className = {css.lernerMobile} src={lernerMobile}/>
 
-    return (
-      <span className={ css.splashPageContainer }>
+  return (
+    <span className={ css.splashPageContainer }>
 
 
-        {/* First Row. */}
-        <Grid stackable className={ css.firstRow }>
-          {/* These widths must add up to 16.*/}
-          <Grid.Column width={ 7 } className={ css.firstRowText }>
-            <div className={ css.firstRowTextInner }>
-              <h1>Instantly search through all of NEU&apos;s classes.</h1>
-              <div className={ css.allTextDesc }>Search through classes, professors, sections, and subjects at Northeastern. Going to add more stuff (like TRACE surveys) soon!</div>
-              <Button onClick={ () => { window.dispatchEvent(searchForCS2510Event); } } primary className={ css.redButton }>Search for CS 2510</Button>
-              <div className={ css.firstRowMobilePadding } />
+      {/* First Row. */}
+      <Grid stackable className={ css.firstRow }>
+        {/* These widths must add up to 16.*/}
+        <Grid.Column width={ 7 } className={ css.firstRowText }>
+          <div className={ css.firstRowTextInner }>
+            <h1>Instantly search through all of NEU&apos;s classes.</h1>
+            <div className={ css.allTextDesc }>Search through classes, professors, sections, and subjects at Northeastern. Going to add more stuff (like TRACE surveys) soon!</div>
+            <Button onClick={ () => { window.dispatchEvent(searchForCS2510Event); } } primary className={ css.redButton }>Search for CS 2510</Button>
+            <div className={ css.firstRowMobilePadding } />
+          </div>
+        </Grid.Column>
+        <Grid.Column width={ 9 } className={ css.rightSideFirstRow }>
+          <div className={ css.firstRowImgContainer }>
+
+            <img className={ css.cs2510Desktop } src={ cs2510Desktop } alt='Example of a result of searching for CS2510' />
+            <div className={ css.rotatedDiv } />
+          </div>
+        </Grid.Column>
+      </Grid>
+
+
+      {/* Second Row. */}
+      <Grid stackable reversed='mobile' className={ css.secondRow }>
+        <Grid.Column width={ 9 } className={ css.secondRowImgContainer }>
+          <img className={ css.engw1111Desktop } src={ engw1111Desktop } alt='Expanded view of a result of searching for ENGW1111' />
+          <img className={ css.lernerMobile } src={ lernerMobile } alt='Mobile view example' />
+          <div className={ css.rotatedDivSecondRow } />
+        </Grid.Column>
+        <Grid.Column width={ 7 } className={ css.secondRowText }>
+          <div className={ css.secondRowTextInner }>
+            <h1>Everything you could be looking for.</h1>
+            <div className={ css.allTextDesc }>See class descriptions, prereqs, coreqs, CRNs, professors, meetings, and locations! Even more stuff coming soon!</div>
+            <Button onClick={ () => { window.dispatchEvent(searchForENGW1111Event); } } primary className={ css.grayButton }>Search for ENGW 1111</Button>
+          </div>
+        </Grid.Column>
+      </Grid>
+
+
+      <Grid stackable className={ css.thirdRow }>
+        <Grid.Column width={ 7 } className={ css.thirdRowText }>
+          <div className={ css.thirdRowTextInner }>
+            <h1>Works great on mobile!</h1>
+            <div className={ css.allTextDesc }>holla holla</div>
+            <Button onClick={ () => { window.dispatchEvent(searchForOODEvent); } } primary className={ css.redButton }>Search for OOD</Button>
+          </div>
+        </Grid.Column>
+        <Grid.Column width={ 9 } className={ css.thirdRowImgContainer }>
+          <div className={ css.thirdRowImgContainerInner }>
+            <div>
+              <img className={ css.oodMobile1 } src={ oodMobile1 } alt='More mobile examples' />
+              <img className={ css.oodMobile2 } src={ oodMobile2 } alt='More mobile examples' />
             </div>
-          </Grid.Column>
-          <Grid.Column width={ 9 } className={ css.rightSideFirstRow }>
-            <div className={ css.firstRowImgContainer }>
-
-              <img className={ css.cs2510Desktop } src={ cs2510Desktop } alt='Example of a result of searching for CS2510' />
-              <div className={ css.rotatedDiv } />
+            <div>
+              <img className={ css.cs2500Mobile } src={ cs2500Mobile } alt='More mobile examples' />
+              <img className={ css.cs2500Resultsmobile } src={ cs2500Resultsmobile } alt='More mobile examples' />
             </div>
-          </Grid.Column>
-        </Grid>
-
-
-        {/* Second Row. */}
-        <Grid stackable reversed='mobile' className={ css.secondRow }>
-          <Grid.Column width={ 9 } className={ css.secondRowImgContainer }>
-            <img className={ css.engw1111Desktop } src={ engw1111Desktop } alt='Expanded view of a result of searching for ENGW1111' />
-            <img className={ css.lernerMobile } src={ lernerMobile } alt='Mobile view example' />
-            <div className={ css.rotatedDivSecondRow } />
-          </Grid.Column>
-          <Grid.Column width={ 7 } className={ css.secondRowText }>
-            <div className={ css.secondRowTextInner }>
-              <h1>Everything you could be looking for.</h1>
-              <div className={ css.allTextDesc }>See class descriptions, prereqs, coreqs, CRNs, professors, meetings, and locations! Even more stuff coming soon!</div>
-              <Button onClick={ () => { window.dispatchEvent(searchForENGW1111Event); } } primary className={ css.grayButton }>Search for ENGW 1111</Button>
-            </div>
-          </Grid.Column>
-        </Grid>
-
-
-        <Grid stackable className={ css.thirdRow }>
-          <Grid.Column width={ 7 } className={ css.thirdRowText }>
-            <div className={ css.thirdRowTextInner }>
-              <h1>Works great on mobile!</h1>
-              <div className={ css.allTextDesc }>holla holla</div>
-              <Button onClick={ () => { window.dispatchEvent(searchForOODEvent); } } primary className={ css.redButton }>Search for OOD</Button>
-            </div>
-          </Grid.Column>
-          <Grid.Column width={ 9 } className={ css.thirdRowImgContainer }>
-            <div className={ css.thirdRowImgContainerInner }>
-              <div>
-                <img className={ css.oodMobile1 } src={ oodMobile1 } alt='More mobile examples' />
-                <img className={ css.oodMobile2 } src={ oodMobile2 } alt='More mobile examples' />
-              </div>
-              <div>
-                <img className={ css.cs2500Mobile } src={ cs2500Mobile } alt='More mobile examples' />
-                <img className={ css.cs2500Resultsmobile } src={ cs2500Resultsmobile } alt='More mobile examples' />
-              </div>
-              <div className={ css.rotatedDivThirdRow } />
-            </div>
-          </Grid.Column>
-        </Grid>
-      </span>
-    );
-  }
+            <div className={ css.rotatedDivThirdRow } />
+          </div>
+        </Grid.Column>
+      </Grid>
+    </span>
+  );
 }
 
 // this was for mobile

--- a/frontend/components/panels/BaseClassPanel.js
+++ b/frontend/components/panels/BaseClassPanel.js
@@ -152,6 +152,9 @@ class BaseClassPanel extends React.Component {
           //   debugger
           // }
 
+          // When adding support for right click-> open in new tab, we might also be able to fix the jsx-a11y/anchor-is-valid errors.
+          // They are disabled for now.
+
 
           const hash = `${childBranch.subject} ${childBranch.classId}`;
 

--- a/frontend/components/panels/DesktopClassPanel.js
+++ b/frontend/components/panels/DesktopClassPanel.js
@@ -158,7 +158,7 @@ class DesktopClassPanel extends BaseClassPanel {
                   length = 6;
                 }
 
-                const onlineElement = 
+                const onlineElement =
                 (
                   <td key='onlineWideCell' colSpan={ length } className={ css.wideOnlineCell }>
                     <span className={ css.onlineDivLineContainer }>

--- a/frontend/components/panels/WeekdayBoxes.js
+++ b/frontend/components/panels/WeekdayBoxes.js
@@ -14,48 +14,46 @@ const cx = classNames.bind(css);
 // This file is responsible for the weekday boxes, eg [][x][][][x] for Tuesday Friday
 // And the string that appears when you hover over it (Meets on Tuesday, Friday)
 
-class WeekdayBoxes extends React.Component {
-  render() {
-    // Don't render anything if the class is online.
-    if (this.props.section.online) {
-      return null;
-    }
-
-
-    // Calculate the "Meets on Tuesday, Friday" or "No Meetings found" string that hovers over the weekday boxes
-    const meetingDays = this.props.section.getWeekDaysAsStringArray();
-    let meetingString;
-    if (meetingDays.length === 0) {
-      meetingString = 'No Meetings found';
-    } else {
-      meetingString = `Meets on ${meetingDays.join(', ')}`;
-    }
-
-    // Calculate the weekday boxes eg [][x][][][x] for Tuesday Friday
-    let booleans = this.props.section.getWeekDaysAsBooleans();
-    if (!this.props.section.meetsOnWeekends()) {
-      booleans = booleans.slice(1, 6);
-    }
-
-    const booleanElements = booleans.map((meets, index) => {
-      return (
-        <div
-          key={ index }
-          className={ cx({
-            weekDayBoxChecked: meets,
-            weekDayBox: true,
-          }) }
-        />
-      );
-    });
-
-
-    return (
-      <div className={ `${css.inlineBlock} ${css.daysContainer}` } data-tip={ meetingString }>
-        {booleanElements}
-      </div>
-    );
+function WeekdayBoxes(props) {
+  // Don't render anything if the class is online.
+  if (props.section.online) {
+    return null;
   }
+
+
+  // Calculate the "Meets on Tuesday, Friday" or "No Meetings found" string that hovers over the weekday boxes
+  const meetingDays = props.section.getWeekDaysAsStringArray();
+  let meetingString;
+  if (meetingDays.length === 0) {
+    meetingString = 'No Meetings found';
+  } else {
+    meetingString = `Meets on ${meetingDays.join(', ')}`;
+  }
+
+  // Calculate the weekday boxes eg [][x][][][x] for Tuesday Friday
+  let booleans = props.section.getWeekDaysAsBooleans();
+  if (!props.section.meetsOnWeekends()) {
+    booleans = booleans.slice(1, 6);
+  }
+
+  const booleanElements = booleans.map((meets, index) => {
+    return (
+      <div
+        key={ index } // eslint-disable-line react/no-array-index-key
+        className={ cx({
+          weekDayBoxChecked: meets,
+          weekDayBox: true,
+        }) }
+      />
+    );
+  });
+
+
+  return (
+    <div className={ `${css.inlineBlock} ${css.daysContainer}` } data-tip={ meetingString }>
+      {booleanElements}
+    </div>
+  );
 }
 
 

--- a/travis_deploy.sh
+++ b/travis_deploy.sh
@@ -9,6 +9,9 @@ set -v
 
 npm run test
 
+# Make sure everything passes linting
+./node_modules/eslint/bin/eslint.js backend/ frontend/ common/
+
 # Pull requests and commits to other branches shouldn't try to deploy
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     echo $TRAVIS_PULL_REQUEST

--- a/travis_deploy.sh
+++ b/travis_deploy.sh
@@ -12,6 +12,10 @@ npm run test
 # Make sure everything passes linting
 ./node_modules/eslint/bin/eslint.js backend/ frontend/ common/
 
+# This step runs regardless of branch, to ensure that any changes to the code did not break the build. 
+echo 'Building the code for production.'
+npm run build
+
 # Pull requests and commits to other branches shouldn't try to deploy
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     echo $TRAVIS_PULL_REQUEST
@@ -33,14 +37,6 @@ git --version
 echo
 bash --version
 echo
-
-# Use this command to get the stuff in prod into the public folder. 
-# time git clone -b gh-pages --single-branch git@github.com:ryanhugh/searchneu.git public
-# rm -rf public/.git
-
-# This step runs regardless of branch, to ensure that any changes to the code did not break the build. 
-echo 'Building the code for production.'
-npm run build
 
 # If this is a cron job, run the scrapers.
 # We are going to combile the backend to ES5 anyway, so might as well run the ES5 to do the scraping too.


### PR DESCRIPTION
- Fixed the rest of the ESLint issues
  - Disabled some of the a11y rules - we don't need to focus on making the site accessible now and can always come back to that 
- Added `eslint-loader` to the webpack build so eslint will run when webpack is building the code and the build will fail if eslint fails
   - Not totally sure if we want to stick with this - maybe change a bunch of the errors to just warnings at this step?
   - But would still require that they pass on Travis
- Required that all the code passes linting on Travis