### PR TITLE
bring updater back

### DIFF
--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -96,7 +96,9 @@ class Elastic {
       },
     });
     return got.body.docs.reduce((result, doc) => {
-      result[doc._id] = doc._source;
+      if (doc.found) {
+        result[doc._id] = doc._source;
+      }
       return result;
     }, {});
   }

--- a/backend/server.js
+++ b/backend/server.js
@@ -22,7 +22,7 @@ import Request from './scrapers/request';
 import webpackConfig from './webpack.config.babel';
 import macros from './macros';
 import notifyer from './notifyer';
-// import Updater from './updater';
+import Updater from './updater';
 import database from './database';
 
 // This file manages every endpoint in the backend
@@ -40,7 +40,7 @@ const fbAppSecret = macros.getEnvVariable('fbAppSecret');
 
 // Start updater interval
 // TODO: FIX!!!!!!
-// Updater.create();
+Updater.create();
 
 // Verify that the webhooks are coming from facebook
 // This needs to be above bodyParser for some reason

--- a/backend/updater.js
+++ b/backend/updater.js
@@ -113,8 +113,8 @@ class Updater {
     }
 
     // Remove duplicates. This will occur if multiple people are watching the same class.
-    classHashes = _.uniq(classHashes);
-    sectionHashes = _.uniq(sectionHashes);
+    classHashes = _(classHashes).uniq().compact();
+    sectionHashes = _(sectionHashes).uniq().compact();
 
     macros.log('watching classes ', classHashes);
 


### PR DESCRIPTION
there was someone in firebase watching for a null classHash, which then got into the elasticsearch query and crashed it. Now stripping out null values from classhash, and also ignoring watched classes that are not in the database 