### PR TITLE
fix cron

### DIFF
--- a/backend/scrapers/classes/main.js
+++ b/backend/scrapers/classes/main.js
@@ -8,7 +8,6 @@ import URI from 'urijs';
 import cache from '../cache';
 import macros from '../../macros';
 import Keys from '../../../common/Keys';
-import searchIndex from './searchIndex';
 import termDump from './termDump';
 import differentCollegeUrls from './differentCollegeUrls';
 import bannerv9CollegeUrls from './bannerv9CollegeUrls';
@@ -247,8 +246,6 @@ class Main {
 
     const dump = this.runProcessors(restructuredData);
 
-
-    await searchIndex.main(dump);
     await termDump.main(dump);
 
     if (macros.DEV) {

--- a/backend/scrapers/employees/matchEmployees.js
+++ b/backend/scrapers/employees/matchEmployees.js
@@ -15,7 +15,6 @@ import ccisFaculty from './ccis';
 import csshFaculty from './cssh';
 import camdFaculty from './camd';
 
-import searchIndex from './searchIndex';
 
 // This file combines the data from the ccis website and the NEU Employees site
 // If there is a match, the data from the ccis site has priority over the data from the employee site.
@@ -374,8 +373,6 @@ class CombineCCISandEmployees {
     const employeeDump = _.keyBy(mergedEmployees, 'id');
 
     await fs.writeFile(path.join(macros.PUBLIC_DIR, 'employeeDump.json'), JSON.stringify(employeeDump));
-
-    await searchIndex.main(employeeDump);
 
     return mergedEmployees;
   }


### PR DESCRIPTION
`yarn scrape` expects an elasticsearch instance to be present on localhost. Breaks the cron job. Now, it just scrapes to a dump. `yarn index` **must** be run to get the scraped data into elasticsearch.