### PR TITLE
add function score query to lower labs, recitations and seminars

### DIFF
--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -129,8 +129,8 @@ class Elastic {
                     fields: [
                       'class.name^2', // Boost by 2
                       'class.name.autocomplete',
-                      'class.subject^3',
-                      'class.classId^2',
+                      'class.subject^4',
+                      'class.classId^3',
                       'sections.meetings.profs',
                       'class.crns',
                       'employee.name^2',
@@ -151,10 +151,10 @@ class Elastic {
             },
             functions: [
               {
-                filter: { 
+                filter: {
                   terms: { 'class.scheduleType.keyword': ['Lab', 'Recitation/Discussion', 'Seminar'] },
                 },
-                weight: 0.1,
+                weight: 0.4,
               },
             ],
           },

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -152,7 +152,7 @@ class Elastic {
             functions: [
               {
                 filter: { 
-                  terms: { 'class.scheduleType.keyword': [ 'Lab', 'Recitation/Discussion', 'Seminar' ] },
+                  terms: { 'class.scheduleType.keyword': ['Lab', 'Recitation/Discussion', 'Seminar'] },
                 },
                 weight: 0.1,
               },

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -119,32 +119,44 @@ class Elastic {
           { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } }, // Use lower classId has tiebreaker after relevance
         ],
         query: {
-          bool: {
-            must: {
-              multi_match: {
-                query: query,
-                type: 'most_fields', // More fields match => higher score
-                fields: [
-                  'class.name^2', // Boost by 2
-                  'class.name.autocomplete',
-                  'class.subject^3',
-                  'class.classId^2',
-                  'sections.meetings.profs',
-                  'class.crns',
-                  'employee.name^2',
-                  'employee.emails',
-                  'employee.phone',
-                ],
-              },
-            },
-            filter: {
+          function_score: {
+            query: {
               bool: {
-                should: [
-                  { term: { 'class.termId': termId } },
-                  { term: { type: 'employee' } },
-                ],
+                must: {
+                  multi_match: {
+                    query: query,
+                    type: 'most_fields', // More fields match => higher score
+                    fields: [
+                      'class.name^2', // Boost by 2
+                      'class.name.autocomplete',
+                      'class.subject^3',
+                      'class.classId^2',
+                      'sections.meetings.profs',
+                      'class.crns',
+                      'employee.name^2',
+                      'employee.emails',
+                      'employee.phone',
+                    ],
+                  },
+                },
+                filter: {
+                  bool: {
+                    should: [
+                      { term: { 'class.termId': termId } },
+                      { term: { type: 'employee' } },
+                    ],
+                  },
+                },
               },
             },
+            functions: [
+              {
+                filter: { 
+                  terms: { 'class.scheduleType.keyword': [ 'Lab', 'Recitation/Discussion', 'Seminar' ] },
+                },
+                weight: 0.1,
+              },
+            ],
           },
         },
       },


### PR DESCRIPTION
Part 2 of lowering labs, recitations, etc. for queries like 'CS' and 'Math'. Adding a function score query to lower any classes of type `Lab`, `Recitation/Discussion`, or `Seminar`.