### PR TITLE
Moved Elasticsearch off Production Webserver VM

### DIFF
--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -6,8 +6,10 @@
 
 import { Client } from '@elastic/elasticsearch';
 import _ from 'lodash';
+import macros from './macros';
 
-const client = new Client({ node: 'http://localhost:9200' });
+const URL = macros.getEnvVariable('elasticURL') || 'http://localhost:9200';
+const client = new Client({ node: URL });
 
 class Elastic {
   constructor() {


### PR DESCRIPTION
https://elasticsearch.searchneu.com:9200/

(requires authentication)
There is a master account, a read/write account for the webserver, and a read-only dev account.

Eventually we could add an account to Travis, so that Travis can index directly into Elasticsearch, instead of SSH-ing into the prod webserver and running `yarn index` but what we have works for now.

PM me if you need access to the dev account, but for the most part we shouldn't be touching this except to debug prod bugs.