### PR TITLE
Make different query if query is course code

### DIFF
--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -134,7 +134,7 @@ class Elastic {
                     fields: [
                       'class.name^2', // Boost by 2
                       'class.name.autocomplete',
-                      'class.subject^4',
+                      'class.subject^5',
                       'class.classId^3',
                       'sections.meetings.profs',
                       'class.crns',
@@ -159,7 +159,7 @@ class Elastic {
                 filter: {
                   terms: { 'class.scheduleType.keyword': ['Lab', 'Recitation/Discussion', 'Seminar'] },
                 },
-                weight: 0.4,
+                weight: 0.5,
               },
             ],
           },

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -124,7 +124,8 @@ class Elastic {
         },
       },
     });
-    return subjects.body.aggregations.subjects.subjects.buckets;
+    return _.map(subjects.body.aggregations.subjects.subjects.buckets, 'key');
+    // subjects.body.aggregations.subjects.subjects.buckets;
   }
 
   /**

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -136,8 +136,7 @@ class Elastic {
    */
   async search(query, termId, min, max) {
     // if we know that the query is of the format of a course code, we want to do a very targeted query against subject and classId: otherwise, do a regular query.
-    let courseCodePattern = /^\s*\w{2,4}\s*\d{4}?\s*$/i
-      // /^(\s)*\w\w(\w?)(\w?)(\s)*(\d\d\d\d)?(\s)*$/i;
+    let courseCodePattern = /^\s*[a-zA-Z]{2,4}\s*\d{4}?\s*$/i
     let fields = [
       'class.name^2', // Boost by 2
       'class.name.autocomplete',

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -113,6 +113,25 @@ class Elastic {
    * @param  {integer} max    The index of last document to retreive
    */
   async search(query, termId, min, max) {
+    // if we know that the query is of the format of a course code, we want to do a very targeted query against subject and classId: otherwise, do a regular query.
+    let courseCodePattern = /^(\s)*\w\w(\w?)(\w?)(\s)*(\d\d\d\d)?(\s)*$/i;
+    let fields = [
+      'class.name^2', // Boost by 2
+      'class.name.autocomplete',
+      'class.subject^4',
+      'class.classId^3',
+      'sections.meetings.profs',
+      'class.crns',
+      'employee.name^2',
+      'employee.emails',
+      'employee.phone',
+    ];
+
+    if (courseCodePattern.test(query)) {
+      // after the first result, all of the following results should be of the same subject, e.g. it's weird to get ENGL2500 as the second or third result for CS2500
+      fields = ['class.subject^10', 'class.classId'];
+    }
+
     const searchOutput = await client.search({
       index: `${this.EMPLOYEE_INDEX},${this.CLASS_INDEX}`,
       from: min,
@@ -123,49 +142,28 @@ class Elastic {
           { 'class.classId.keyword': { order: 'asc', unmapped_type: 'keyword' } }, // Use lower classId has tiebreaker after relevance
         ],
         query: {
-          function_score: {
-            query: {
-              bool: {
-                must: {
-                  multi_match: {
-                    query: query,
-                    type: 'most_fields', // More fields match => higher score
-                    fuzziness: 'AUTO',
-                    fields: [
-                      'class.name^2', // Boost by 2
-                      'class.name.autocomplete',
-                      'class.subject^5',
-                      'class.classId^3',
-                      'sections.meetings.profs',
-                      'class.crns',
-                      'employee.name^2',
-                      'employee.emails',
-                      'employee.phone',
-                    ],
-                  },
-                },
-                filter: {
-                  bool: {
-                    should: [
-                      { term: { 'class.termId': termId } },
-                      { term: { type: 'employee' } },
-                    ],
-                  },
-                },
+          bool: {
+            must: {
+              multi_match: {
+                query: query,
+                type: 'most_fields', // More fields match => higher score
+                fuzziness: 'AUTO',
+                fields: fields,
               },
             },
-            functions: [
-              {
-                filter: {
-                  terms: { 'class.scheduleType.keyword': ['Lab', 'Recitation/Discussion', 'Seminar'] },
-                },
-                weight: 0.5,
+            filter: {
+              bool: {
+                should: [
+                  { term: { 'class.termId': termId } },
+                  { term: { type: 'employee' } },
+                ],
               },
-            ],
+            },
           },
         },
       },
     });
+
     return {
       searchContent: searchOutput.body.hits.hits.map((hit) => { return { ...hit._source, score: hit._score }; }),
       resultCount: searchOutput.body.hits.total.value,

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -111,14 +111,20 @@ class Elastic {
       body: {
         aggs: {
           subjects: {
-            terms: {
-              field: "subject.keyword",
+            global: {},
+            aggs: {
+              subjects: {
+                terms: {
+                  field: "class.subject.keyword",
+                  size: 10000 // anything that will get everything
+                },
+              },
             },
           },
         },
       },
     });
-    console.log(subjects.body.aggregations.subjects);
+    return subjects.body.aggregations.subjects.subjects.buckets;
   }
 
   /**
@@ -180,8 +186,6 @@ class Elastic {
         },
       },
     });
-
-    this.getSubjectsFromClasses();
 
     return {
       searchContent: searchOutput.body.hits.hits.map((hit) => { return { ...hit._source, score: hit._score }; }),

--- a/backend/elastic.js
+++ b/backend/elastic.js
@@ -140,7 +140,9 @@ class Elastic {
    * @param  {integer} max    The index of last document to retreive
    */
   async search(query, termId, min, max) {
-    this.subjects = this.subjects || new Set(await this.getSubjectsFromClasses());
+    if (!this.subjects) {
+      this.subjects = new Set(await this.getSubjectsFromClasses());
+    }
 
     // if we know that the query is of the format of a course code, we want to do a very targeted query against subject and classId: otherwise, do a regular query.
     let courseCodePattern = /^\s*([a-zA-Z]{2,4})\s*(\d{4})?\s*$/i
@@ -157,7 +159,7 @@ class Elastic {
     ];
 
     const patternResults = query.match(courseCodePattern);
-    if (patternResults && this.subjects.has(patternResults[1])) {
+    if (patternResults && this.subjects.has(patternResults[1].toLowerCase())) {
       // after the first result, all of the following results should be of the same subject, e.g. it's weird to get ENGL2500 as the second or third result for CS2500
       fields = ['class.subject^10', 'class.classId'];
     }

--- a/backend/scrapers/classes/classMapping.json
+++ b/backend/scrapers/classes/classMapping.json
@@ -29,7 +29,13 @@
           },
           "subject": {
             "type": "text",
-            "analyzer": "course_code"
+            "analyzer": "course_code",
+            "fields": {
+              "keyword": {
+                "type": "keyword",
+                "ignore_above": 256
+              }
+            }
           },
           "prereqs": {
             "type": "object",

--- a/backend/scrapers/classes/classMapping.json
+++ b/backend/scrapers/classes/classMapping.json
@@ -33,7 +33,7 @@
             "fields": {
               "keyword": {
                 "type": "keyword",
-                "ignore_above": 256
+                "ignore_above": 4
               }
             }
           },

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -31,4 +31,31 @@ describe('elastic', () => {
     let firstResult = getFirstClassResult(await elastic.search('fundies', '202010', 0, 1));
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
+
+  [['cs', '2500'], ['cs', '2501', 'thtr', '1000'].forEach((item, index, array) => {
+    it(`always analyzes course code  ${item.join(' ')} the same way regardless of string`, async () => {
+      let canonicalResult = getFirstClassResult(await elastic.search(item.join(' '), '202010', 0, 1));
+
+      let firstResult = getFirstClassResult(await elastic.search(item.join(''), '202010', 0, 1));
+      expect(Keys.getClassHash(firstResult)).toBe(Keys.getClassHash(canonicalResult));
+ 
+      let secondResult = getFirstClassResult(await elastic.search(item.join(' ').toUpperCase(), '202010', 0, 1));
+      expect(Keys.getClassHash(secondResult)).toBe(Keys.getClassHash(canonicalResult));
+
+      let thirdResult = getFirstClassResult(await elastic.search(item.join('').toUpperCase(), '202010', 0, 1));
+      expect(Keys.getClassHash(thirdResult)).toBe(Keys.getClassHash(canonicalResult));
+    });
+  });
 });
+
+/*
+ * tests I need:
+ * 1. test blank?
+ * 2. test bogus?
+ * 3. test typos?
+ * 4. test that course codes work as expected, so:
+ *    --> spaces don't change anything
+ *    --> capitalization doesn't change anything
+ *    --> all the following results are of the same subject type not the same classId
+ * 5. typing in niche things like emails and whatnot always fetch the right thing
+ */

--- a/regtests/search.test.js
+++ b/regtests/search.test.js
@@ -32,13 +32,14 @@ describe('elastic', () => {
     expect(Keys.getClassHash(firstResult)).toBe('neu.edu/202010/CS/2500');
   });
 
-  [['cs', '2500'], ['cs', '2501', 'thtr', '1000'].forEach((item, index, array) => {
+  [['cs', '2500'], ['cs', '2501'], ['thtr', '1000']].forEach((item, index, array) => {
     it(`always analyzes course code  ${item.join(' ')} the same way regardless of string`, async () => {
       let canonicalResult = getFirstClassResult(await elastic.search(item.join(' '), '202010', 0, 1));
 
       let firstResult = getFirstClassResult(await elastic.search(item.join(''), '202010', 0, 1));
       expect(Keys.getClassHash(firstResult)).toBe(Keys.getClassHash(canonicalResult));
  
+      console.log(item.join(' ').toUpperCase());
       let secondResult = getFirstClassResult(await elastic.search(item.join(' ').toUpperCase(), '202010', 0, 1));
       expect(Keys.getClassHash(secondResult)).toBe(Keys.getClassHash(canonicalResult));
 

--- a/travis_deploy.sh
+++ b/travis_deploy.sh
@@ -14,7 +14,7 @@ set -v
 # Might be worth looking into this again if the jobs are slow in the future. 
 
 # We can't use npm run test directly because it adds some output, which messes up coveralls
-./node_modules/jest-cli/bin/jest.js --coverage --coverageReporters=text-lcov | ./node_modules/coveralls/bin/coveralls.js
+./node_modules/jest-cli/bin/jest.js --coverage --coverageReporters=text-lcov --testPathIgnorePatterns='regtest' | ./node_modules/coveralls/bin/coveralls.js
 
 # Make sure everything passes linting
 # Run the commands separately, so if one fails, this script fails


### PR DESCRIPTION
This change fixes multiple issues:
1. the query bug where `cs2501` returns different results from `cs 2501`. The reason this was happening is that the `course_code` analyzer was actually working, but because the `name` field doesn't have the `word_delimiter` filter, it parses the course code as a single token. Turns out the `cs` token in the query actually gives `cs2501` a significant boost because it has the token `CS` in its title, which is the only reason it was showing up as first to begin with. *Not good*.

2. removes the hackiness of the function score. It was only working by a delicate balance anyway, with a 0.4 factor on non-primary courses and small changes in boosts for different fields to get the numbers just right. Removes that entirely.

3. making more intelligent queries altogether. If we know somebody's making a course code query, we should be doing two things:
    a. only query against `subject` and `classId`. 
    b. the following results should all be of the same subject rather than having the same classId. For example, if you search for `cs2500`, you should get fundies 1 as the first result, then CS classes as the rest of your search results. Getting `ENGL2500` would be very weird.

P.S. a few last things necessary before this goes out plus some general tests to throw in as well.